### PR TITLE
fix examples in quickstart

### DIFF
--- a/Quickstart/launching_your_first_pod.md
+++ b/Quickstart/launching_your_first_pod.md
@@ -13,6 +13,7 @@ spec:
   - name: alpine
     image: alpine
 EOF
+
 $ pi create -f /tmp/alpine.yml
 pod/alpine
 ```

--- a/Quickstart/understand_network.md
+++ b/Quickstart/understand_network.md
@@ -25,7 +25,7 @@ To expose a _service_ on the Internet, a _Floating IP_ must be associated with t
 
 ```bash
 $ pi create fip
-104.154.140.179
+fip/104.154.140.179
 ```
 
 Next define the service spec. Here we use the `LoadBalancer` type with the allocated floating IP, and use `selector` for pods with the label `app: nginx`, finally map the port to `80`:
@@ -85,8 +85,10 @@ Floating IPs are independent from the pod, therefore you need to release them se
 ```sh
 $ pi delete pod nginx
 pod "nginx" deleted
+
 $ pi delete service test-loadbalancer
 service "test-loadbalancer" deleted
+
 $ pi delete fip 104.154.140.179
 fip "104.154.140.179" deleted
 ```

--- a/Quickstart/use_volume_for_stateful_workload.md
+++ b/Quickstart/use_volume_for_stateful_workload.md
@@ -24,6 +24,8 @@ spec:
     volumeMounts:
     - name: data
       mountPath: /data
+  nodeSelector:
+    zone: gcp-us-central1-a
   volumes:
   - name: data
     flexVolume:
@@ -37,16 +39,20 @@ pod/busybox
 Now, let's create a file on the volume:
 
 ```sh
-$ pi exec busybox -c busybox -- echo "Hello World" > /data/hello.txt
+$ pi exec busybox -c busybox -- sh -c 'echo "Hello World" > /data/hello.txt'
+$ pi exec busybox -c busybox -- cat /data/hello.txt
+Hello World
 ```
 
 To demonstrate the data persistence, we'll delete the pod, and create another a new one with the same volume to see whether the file is still there:
 
 ```sh
-$ pi delete pod busybox
+$ pi delete pod busybox --now
 pod "busybox" deleted
+
 $ pi create -f /tmp/busybox.yml
 pod/busybox
+
 $ pi exec busybox -c busybox -- cat /data/hello.txt
 Hello World
 ```
@@ -63,6 +69,7 @@ Volumes are indepedent resources, and only removable when they are not mounted.
 ```sh
 $ pi delete pod busybox
 pod "busybox" deleted
+
 $ pi delete volume data
 volume "data" deleted
 ```

--- a/Quickstart/working_with_multi-container_pod.md
+++ b/Quickstart/working_with_multi-container_pod.md
@@ -25,6 +25,7 @@ spec:
   - name: nginx
     image: nginx
 EOF
+
 $ pi create -f /tmp/multi-basic.yml
 pod/multi-basic
 ```
@@ -33,18 +34,19 @@ You can access a particular container by specifying the container name in the `p
 
 ```sh
 $ pi exec -it multi-basic --container busybox -- /bin/sh
+
 $ pi exec -it multi-basic -c nginx -- /bin/sh
 ```
 
 > Note:
 > If _--container_ is absent, the first container in the pod spec will be the default container to execute the command.
 
-Now, let's these two containers' filesystem:
+Now, let's check these two containers' filesystem:
 
 ```sh
-$ pi exec multi-basic --container busybox -- file /etc/nginx.conf
-/etc/nginx.conf: cannot open '/etc/nginx.conf' (No such file or directory)
+$ pi exec multi-basic --container busybox -- ls /etc/nginx/nginx.conf
+ls: /etc/nginx/nginx.conf: No such file or directory
 
-$ pi exec multi-basic --container nginx -- file /etc/nginx.conf
-/etc/nginx/nginx.conf: ASCII English text
+$ pi exec multi-basic --container nginx -- ls /etc/nginx/nginx.conf
+/etc/nginx/nginx.conf
 ```


### PR DESCRIPTION
fix following examples:
-1.2. Launch Your First Pod
-1.3. Understand the network
-1.4. Use Volume for Stateful Workload
-1.5. Work with Multi-container Pod